### PR TITLE
Walk the source directory tree and convert everything in one pass

### DIFF
--- a/directory.go
+++ b/directory.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func ConvertDirectory(in, out, pkg string, writer Writer) error {
+	entries, err := ioutil.ReadDir(in)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		p := filepath.Join(in, entry.Name())	
+		if entry.IsDir() {
+			err = ConvertDirectory(p, filepath.Join(out, entry.Name()))
+			if err != nil {
+				return err
+			}
+		} else {
+			variable, err := ConvertFile(
+				p, filepath.Join(out, fmt.Sprintf("%s.go", entry.Name())), pkg)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(ofi, "\t\"%s\": %s,\n", entry.Name(), variable)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	_, err = ofi.Write([]byte("}\n"))
+	return err
+}

--- a/file.go
+++ b/file.go
@@ -23,8 +23,14 @@ func ConvertFile(in, out, pkg string) error {
 	defer ofi.Close()
 	defer infi.Close()
 
-	fmt.Fprintf(ofi, templateStart, pkg, convertName(in))
-	io.Copy(ofi, infi)
-	ofi.Write([]byte("`\n"))
-	return nil
+	_, err = fmt.Fprintf(ofi, templateStart, pkg, convertName(in))
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(ofi, infi)
+	if err != nil {
+		return err
+	}
+	_, err = ofi.Write([]byte("`\n"))
+	return err
 }

--- a/file.go
+++ b/file.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+var templateStart = `package %s
+var %s = ` + "`"
+
+func ConvertFile(in, out, pkg string) error {
+	infi, err := os.Open(in)
+	if err != nil {
+		return err
+	}
+
+	ofi, err := os.Create(out)
+	if err != nil {
+		return err
+	}
+
+	defer ofi.Close()
+	defer infi.Close()
+
+	fmt.Fprintf(ofi, templateStart, pkg, convertName(in))
+	io.Copy(ofi, infi)
+	ofi.Write([]byte("`\n"))
+	return nil
+}

--- a/file.go
+++ b/file.go
@@ -6,31 +6,33 @@ import (
 	"os"
 )
 
-var templateStart = `package %s
+var fileTemplateStart = `package %s
 var %s = ` + "`"
 
-func ConvertFile(in, out, pkg string) error {
+func ConvertFile(in, out, pkg string) (variable string, err error) {
+	variable = convertName(in)
+
 	infi, err := os.Open(in)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	ofi, err := os.Create(out)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	defer ofi.Close()
 	defer infi.Close()
 
-	_, err = fmt.Fprintf(ofi, templateStart, pkg, convertName(in))
+	_, err = fmt.Fprintf(ofi, fileTemplateStart, pkg, variable)
 	if err != nil {
-		return err
+		return "", err
 	}
 	_, err = io.Copy(ofi, infi)
 	if err != nil {
-		return err
+		return "", err
 	}
 	_, err = ofi.Write([]byte("`\n"))
-	return err
+	return variable, err
 }

--- a/main.go
+++ b/main.go
@@ -2,41 +2,7 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"io"
-	"os"
-	"strings"
 )
-
-var templateStart = `package %s
-var %s = ` + "`"
-
-func convertName(name string) string {
-	name = strings.Replace(name, "/", "_", -1)
-	name = strings.Replace(name, ".", "_", -1)
-	name = strings.Replace(name, "-", "_", -1)
-	return strings.Title(name)
-}
-
-func ConvertFile(in, out, pkg string) error {
-	infi, err := os.Open(in)
-	if err != nil {
-		return err
-	}
-
-	ofi, err := os.Create(out)
-	if err != nil {
-		return err
-	}
-
-	defer ofi.Close()
-	defer infi.Close()
-
-	fmt.Fprintf(ofi, templateStart, pkg, convertName(in))
-	io.Copy(ofi, infi)
-	ofi.Write([]byte("`\n"))
-	return nil
-}
 
 func main() {
 	input := flag.String("in", "", "specify input file")

--- a/main.go
+++ b/main.go
@@ -5,12 +5,11 @@ import (
 )
 
 func main() {
-	input := flag.String("in", "", "specify input file")
-	output := flag.String("out", "", "specify output filename")
-	pkgname := flag.String("package", "", "specify package name for output")
+	input := flag.String("in", "", "specify input directory")
+	output := flag.String("out", ".", "specify output directory")
 	flag.Parse()
 
-	err := ConvertFile(*input, *output, *pkgname)
+	err := ConvertTree(input, output)
 	if err != nil {
 		panic(err)
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"strings"
+)
+
+func convertName(name string) string {
+	name = strings.Replace(name, "/", "_", -1)
+	name = strings.Replace(name, ".", "_", -1)
+	name = strings.Replace(name, "-", "_", -1)
+	return strings.Title(name)
+}


### PR DESCRIPTION
This is a work-in-progress.  I'd started off writing it up to just
convert a single directory (via `directory.go`).  But then I decided
it would be better to walk the whole source tree and convert it into a
_single_ asset package (via `tree.go`), since it frees the consumer
from having to know the full directory structure ahead of time.  I
stopped before completing the directory.go → tree.go conversion
though, since I think it's best to just use @jbenet's IPFS-object
bundler (.dar?) to seed the local object store for IPFS installs.
That way we don't have to go through Go to fake a recursive add here
[1](https://github.com/ipfs/go-ipfs/blob/v0.3.3/cmd/ipfs/init.go#L120).
